### PR TITLE
Fixed a few bugs

### DIFF
--- a/BigBrother.lua
+++ b/BigBrother.lua
@@ -1385,7 +1385,6 @@ COMBATLOG_OBJECT_TYPE_GUARDIAN) -- totems
 local wasRemoved = false
 local savedRemoval = 202849 --Dummy spell
 local savedDST = nil
-local savedSRC = nil
 
 local CombatLogGetCurrentEventInfo = CombatLogGetCurrentEventInfo
 function addon:COMBAT_LOG_EVENT_UNFILTERED()
@@ -1437,13 +1436,12 @@ function addon:COMBAT_LOG_EVENT_UNFILTERED()
     if wasRemoved then
         wasRemoved = false
         local isDST = (savedDST == DST)
-        local isSRC = (savedSRC == SRC)
 
-        if isDST and isSRC then
+        if isDST then
             spam = L["%s on %s broken by %s's %s"]:format(SPELL(savedRemoval), DST, SRC, SPELL(spellID))
             sendspam(spam, nil, srcname)
         else
-            spam = L["%s on %s broken for unknown reasons. (Destination was: %s and Source was: %s)"]:format(SPELL(savedRemoval), savedDST, tostring(isDST), tostring(isSRC))
+            spam = L["%s on %s broken for unknown reasons. (Destination was %s not %s)"]:format(SPELL(savedRemoval), savedDST, DST, savedDST)
             sendspam(spam, nil, nil)
         end
     end
@@ -1606,7 +1604,6 @@ function addon:COMBAT_LOG_EVENT_UNFILTERED()
                  wasRemoved = true
                  savedRemoval = spellID
                  savedDST = DST
-                 savedSRC = SRC
                  --spam = (L["%s on %s removed for unknown reasons. (%s)"]):format(SPELL(spellID), DST, SRC)
              else
                  print("What happened?")

--- a/BigBrother.lua
+++ b/BigBrother.lua
@@ -1,14 +1,13 @@
 --[[
 BigBrother
 Concept and original mod: Cryect
-Currently maintained by: oscarucb
+Currently maintained by: JackXC
 Additional thanks:
 * All of the translators
 * Other wowace developers for assistance and bug fixes
 * Ahti and the other members of Cohors Praetoria (Vek'nilash US) for beta testing new versions of the mod
 * Thanks to vhaarr for helping Cryect out with reducing the length of code
 * Thanks to pastamancer for fixing the issues with Supreme Power Flasks and pointing in right direction for others
-* Thanks to rawillkill for the Fix for BFA postet on curse
 * Window Resizing code based off the dragbar from violation
 * And also thanks to all those in #wowace for the various suggestions
 ]]
@@ -19,6 +18,9 @@ if AceLibrary:HasInstance("FuBarPlugin-2.0") then
 else
     BigBrother = AceLibrary("AceAddon-2.0"):new("AceConsole-2.0", "AceDB-2.0", "AceEvent-2.0")
 end
+
+-- Change here and in BigBrother.lua
+local spellidmin = 250000 -- minimum allowed spellid in this addon (bfa: 250000)
 
 -- BigBrother.debug = true
 
@@ -132,7 +134,7 @@ local options = {
     type = 'group',
     handler = BigBrother,
     args = {
-        flaskcheck = {
+        --[[flaskcheck = {
             name = L["Flask Check"],
             desc = L["Checks for flasks, elixirs and food buffs."],
             type = 'group',
@@ -190,10 +192,10 @@ local options = {
                     passValue = "WHISPER",
                 }
             }
-        },
+        },]]--
         quickcheck = {
-            name = L["Quick Check"],
-            desc = L["A quick report that shows who does not have flasks, elixirs or food."],
+            name = L["Check"],
+            desc = L["A report that shows who does not have flasks, elixirs or food."],
             type = 'group',
             args = {
                 self = {
@@ -637,10 +639,11 @@ local options = {
             }
         },
         buffcheck = {
-            name = L["BuffCheck"],
-            desc = L["Pops up a window to check various raid/elixir buffs (drag the bottom to resize)."],
+            name = L["QuickCheck"],
+            desc = L["QuickCheck"],
             type = 'execute',
-            func = function() BigBrother:ToggleBuffWindow() end,
+            func = 'QuickCheck',
+            passValue = "SELF",
         }
     }
 }
@@ -872,9 +875,12 @@ function addon:ConsumableCheck(Where, Full)
     -- Print the flask list and determine who has no flask
     for i, v in ipairs(vars.Flasks) do
         local spellName, spellIcon, spellId = unpack(v)
-        local t = self:BuffPlayerList(spellId, MissingFlaskList)
-        if Full and self.db.profile.CheckFlasks then
-            self:SendMessageList(spellName, t, Where)
+        --check if a buff is from this addon
+        if spellId>spellidmin then
+            local t = self:BuffPlayerList(spellId, MissingFlaskList)
+            if Full and self.db.profile.CheckFlasks then
+                self:SendMessageList(spellName, t, Where)
+            end
         end
     end
 
@@ -882,9 +888,12 @@ function addon:ConsumableCheck(Where, Full)
     if self.db.profile.CheckElixirs then
         for i, v in ipairs(vars.Elixirs) do
             local spellName, spellIcon, spellId = unpack(v)
-            local t = self:BuffPlayerList(spellId, MissingFlaskList)
-            if Full then
-                self:SendMessageList(spellName, t, Where)
+            --check if a buff is from this addon
+            if spellId>spellidmin then
+                local t = self:BuffPlayerList(spellId, MissingFlaskList)
+                if Full then
+                    self:SendMessageList(spellName, t, Where)
+                end
             end
         end
 
@@ -894,8 +903,12 @@ function addon:ConsumableCheck(Where, Full)
                 numElixirs = 0
                 for i, v in ipairs(vars.Elixirs) do
                     local spellName, spellIcon, spellId = unpack(v)
-                    if UnitBuff(unit.unitid, spellId) then
-                        numElixirs = numElixirs + 1
+
+                    --check if a buff is from this addon
+                    if spellId<spellidmin then
+                        if UnitBuff(unit.unitid, spellId) then
+                            numElixirs = numElixirs + 1
+                        end
                     end
                 end
                 if numElixirs == 1 then
@@ -986,14 +999,19 @@ function addon:ConsumableCheck(Where, Full)
         self:SendMessageList(L["No Intellect"], MissingIntBuffList, Where)
         self:SendMessageList(L["No Attack Power"], MissingAPBuffList, Where)
         self:SendMessageList(L["No Stamina"], MissingStaBuffList, Where)
-        self:SendMessageList(L["Missing All Buffs"], MissingAllCombatBuffList, Where)
+        --self:SendMessageList(L["Missing All Buffs"], MissingAllCombatBuffList, Where)
     end
 
     --check for missing food
     if self.db.profile.CheckFood then
         for i, v in ipairs(vars.Foodbuffs) do
             local spellName, spellIcon, spellId = unpack(v)
-            local t = self:BuffPlayerList(spellId, MissingFoodList)
+
+            --check if a buff is from this addon
+            if spellId>spellidmin then
+                self:BuffPlayerList(spellId, MissingFoodList)
+            end
+
         end
         self:SendMessageList(L["No Food Buff"], MissingFoodList, Where)
     end
@@ -1562,7 +1580,7 @@ function addon:COMBAT_LOG_EVENT_UNFILTERED()
              elseif expired then
                  spam = (L["%s on %s expired"]):format(SPELL(spellID), DST)
              elseif subevent == "SPELL_AURA_REMOVED" then
-                 spam = (L["%s on %s removed by %s"]):format(SPELL(spellID), DST, SRC)
+                 spam = (L["%s on %s removed for unknown reasons. (%s)"]):format(SPELL(spellID), DST, SRC)
              end
 
                 -- Should we throttle the spam?

--- a/BigBrother.toc
+++ b/BigBrother.toc
@@ -1,4 +1,4 @@
-## Interface: 80100
+## Interface: 80000
 ## Title: Big Brother
 ## Notes: Checks Raid Buffs/Flasks/Consumables. Tunable alerts for misdirects, taunts, cc breakage, rez, dispel and interrupt
 ## Notes-deDE: Prüft Raidbuffs/Fläschchen & warnt wer Verwandlungen/Untote fesseln unterbricht.

--- a/BigBrother.toc
+++ b/BigBrother.toc
@@ -1,4 +1,4 @@
-## Interface: 70200
+## Interface: 80100
 ## Title: Big Brother
 ## Notes: Checks Raid Buffs/Flasks/Consumables. Tunable alerts for misdirects, taunts, cc breakage, rez, dispel and interrupt
 ## Notes-deDE: Prüft Raidbuffs/Fläschchen & warnt wer Verwandlungen/Untote fesseln unterbricht.
@@ -7,11 +7,11 @@
 ## Notes-zhCN: 插件团队增益及合剂效果，并对打破变形/亡灵束缚进行报警
 ## Notes-zhTW: 檢查團隊 增益/精煉，並警報誰破壞了 變形術/束縛不死生物
 ## Notes-koKR: 공격대 버프 & 영약 & 비약 & 음식 검사/변이 & 속박 등 공격대원의 재사용 대기 시간을 바 형태로 표시
-## Author: Cryect, oscarucb, Treibh, Silberbüchse, Quaiche
-## Version: 4.2.1
-## X-Build: 405
-## X-ReleaseDate: 2015-11-22T17:45:02Z
-## X-Revision: $Revision: 402 $
+## Author: Cryect, oscarucb, Treibh, Silberbüchse, Quaiche, JackXC (since v5.0.0)
+## Version: 5.0.0
+## X-Build: 500
+## X-ReleaseDate: 2018-09-15
+## X-Revision: $Revision: 500 $
 ## X-Category: Raid
 ## X-Embeds: Ace2, RosterLib, FuBarPlugin-2.0
 ## OptionalDeps: Ace2, RosterLib, FuBarPlugin-2.0, FuBar2Broker
@@ -20,7 +20,7 @@
 ## X-LoadOn-Group: true
 ## X-LoadOn-Slash: /bb, /bigbrother
 ## X-LoadOn-LDB-Launcher: Interface\AddOns\BigBrother\icon
-## X-Curse-Packaged-Version: 4.2.1
+## X-Curse-Packaged-Version: 5.0.0
 ## X-Curse-Project-Name: BigBrother
 ## X-Curse-Project-ID: big-brother
 ## X-Curse-Repository-ID: wow/big-brother/mainline

--- a/BuffWindow.lua
+++ b/BuffWindow.lua
@@ -398,18 +398,18 @@ function BuffWindow_Functions:OnEnterBuff()
         self.remTime = math.floor((select(6,AuraUtil.FindAuraByName(self.BuffName, self.unit))-GetTime())/60)
 
         if self.remTime < 0 then
-            self.remTime = "unknown"
+            GameTooltip:AddLine("unknown time remaining",1,1,1)
         elseif self.remTime > 60 then
             self.remTime = math.floor(self.remTime/60)
             if self.remTime == 1 then
-                GameTooltip:AddLine(self.remTime .. " hour remaining")
+                GameTooltip:AddLine(self.remTime .. " hour remaining",1,1,1)
             else
-                GameTooltip:AddLine(self.remTime .. " hours remaining")
+                GameTooltip:AddLine(self.remTime .. " hours remaining",1,1,1)
             end
         elseif self.remTime == 1 then
-            GameTooltip:AddLine(self.remTime .. " minute remaining")
+            GameTooltip:AddLine(self.remTime .. " minute remaining",1,1,1)
         else
-            GameTooltip:AddLine(self.remTime .. " minutes remaining")
+            GameTooltip:AddLine(self.remTime .. " minutes remaining",1,1,1)
         end
     end
 
@@ -788,9 +788,11 @@ function BuffWindow_UpdateWindow()
                 if Player.buff[j] then
                     --check if a buff is from this addon
                     dimmthis = true
-                    if Player.buff[j][3]>spellidmin then
-                        dimmthis = false
-                    end
+					if tonumber(Player.buff[j][3]) ~= nil then
+						if Player.buff[j][3]>spellidmin then
+							dimmthis = false
+						end
+					end;
 
                     Rows[i+roffset]:SetBuffIcon(j,Player.buff[j][2],dimmthis)
                     Rows[i+roffset]:SetBuffName(j,Player.buff[j][1], Player.unit)

--- a/BuffWindow.lua
+++ b/BuffWindow.lua
@@ -7,6 +7,11 @@ local bit, math, date, string, select, table, time, tonumber, unpack, wipe, pair
 local GetSpellInfo, UnitBuff, UnitIsConnected, UnitIsDeadOrGhost =
       GetSpellInfo, UnitBuff, UnitIsConnected, UnitIsDeadOrGhost
 
+-- Change here and in BigBrother.lua
+local spellidmin = 250000 -- minimum allowed spellid in this addon (bfa: 250000)
+
+local foodmin = 41 -- minimum food stat level to allow
+
 local BarHeight=18
 local BarWidth=250
 local WindowWidth=BarWidth+32
@@ -93,7 +98,6 @@ for i,v in ipairs(vars.SpellData.foods) do
 	table.insert(vars.Foodbuffs,  { spellData(v) })
 end
 
-local foodmin = 74 -- minimum food stat level to allow
 local scanfoodcache = {}
 local scantt = CreateFrame("GameTooltip", "BigBrotherScanTooltip", UIParent, "GameTooltipTemplate")
 local function scanfood(spellid)
@@ -110,9 +114,9 @@ local function scanfood(spellid)
   for v in string.gmatch(line, "%d+") do  -- assume largest number in tooltip is the statval
      statval = math.max(statval,tonumber(v))
   end
-  if statval >= 100 and string.find(line, ITEM_MOD_STAMINA_SHORT) then -- normalize for MoP stam bonus
-     statval = statval * 300 / 450
-  end
+  --if statval >= 100 and string.find(line, ITEM_MOD_STAMINA_SHORT) then -- normalize for MoP stam bonus
+    --  statval = statval * 300 / 450
+  --end
   --print(spellid, f[1], statval)
   if statval >= foodmin or
      spellid == 66623 then -- bountiful feast
@@ -320,7 +324,7 @@ function BuffWindow_Functions:CreateBuffRow(parent, xoffset, yoffset)
 	      local status = guid and BigBrother.unitstatus[guid]
 	      if status then
 	        GameTooltip:SetOwner(self, "ANCHOR_TOPRIGHT")
-		GameTooltip:ClearLines();
+		    GameTooltip:ClearLines();
 	        local gotone
 		for k,v in pairs(status) do
 		  if k ~= "highlight" then
@@ -361,6 +365,9 @@ function BuffWindow_Functions:CreateBuffRow(parent, xoffset, yoffset)
 		Row.Buff[i]:SetScript("OnEnter", BuffWindow_Functions.OnEnterBuff)
 		Row.Buff[i]:SetScript("OnLeave", BuffWindow_Functions.OnLeaveBuff)
 		Row.Buff[i]:EnableMouse(true)
+		
+		Row.Buff[i].ID = nil
+        Row.Buff[i].remTime = 0
 
 		Row.Buff[i]:Show()
 	end
@@ -383,10 +390,27 @@ function BuffWindow_Functions:OnEnterBuff()
 	    GameTooltip:AddLine(line)
 	  end
 	else
-		print(self.BuffName)
-		print(self.unit)
-		print('here')
-	  -- GameTooltip:SetUnitBuff(self.unit, self.BuffName)
+        --show buff by id
+        self.ID = select(10,AuraUtil.FindAuraByName(self.BuffName, self.unit))
+        GameTooltip:AddSpellByID(self.ID)
+
+        --show remaining time in minutes
+        self.remTime = math.floor((select(6,AuraUtil.FindAuraByName(self.BuffName, self.unit))-GetTime())/60)
+
+        if self.remTime < 0 then
+            self.remTime = "unknown"
+        elseif self.remTime > 60 then
+            self.remTime = math.floor(self.remTime/60)
+            if self.remTime == 1 then
+                GameTooltip:AddLine(self.remTime .. " hour remaining")
+            else
+                GameTooltip:AddLine(self.remTime .. " hours remaining")
+            end
+        elseif self.remTime == 1 then
+            GameTooltip:AddLine(self.remTime .. " minute remaining")
+        else
+            GameTooltip:AddLine(self.remTime .. " minutes remaining")
+        end
     end
 
 	GameTooltip:Show()
@@ -761,13 +785,19 @@ function BuffWindow_UpdateWindow()
 			local Player=PlayerList[i+offset]
 			Rows[i+roffset]:SetPlayer(Player.name,Player.class,Player.unit)
 			for j=1,TotalBuffs do
-				if Player.buff[j] then
-					Rows[i+roffset]:SetBuffIcon(j,Player.buff[j][2],Player.buff[j][4])
-					Rows[i+roffset]:SetBuffName(j,Player.buff[j][1], Player.unit)
-					Rows[i+roffset]:SetBuffValue(j,true)
-				else
-					Rows[i+roffset]:SetBuffValue(j,false)
-				end
+                if Player.buff[j] then
+                    --check if a buff is from this addon
+                    dimmthis = true
+                    if Player.buff[j][3]>spellidmin then
+                        dimmthis = false
+                    end
+
+                    Rows[i+roffset]:SetBuffIcon(j,Player.buff[j][2],dimmthis)
+                    Rows[i+roffset]:SetBuffName(j,Player.buff[j][1], Player.unit)
+                    Rows[i+roffset]:SetBuffValue(j,true)
+                else
+                    Rows[i+roffset]:SetBuffValue(j,false)
+                end
 			end
 			Rows[i+roffset]:Show()
 		else

--- a/BuffWindow.lua
+++ b/BuffWindow.lua
@@ -8,9 +8,9 @@ local GetSpellInfo, UnitBuff, UnitIsConnected, UnitIsDeadOrGhost =
       GetSpellInfo, UnitBuff, UnitIsConnected, UnitIsDeadOrGhost
 
 -- Change here and in BigBrother.lua
-local spellidmin = 250000 -- minimum allowed spellid in this addon (bfa: 250000)
+local spellidmin = 250000 -- minimum allowed spellid in this addon (bfa is > 250000)
 
-local foodmin = 41 -- minimum food stat level to allow
+local foodmin = 40 -- minimum food stat level to allow
 
 local BarHeight=18
 local BarWidth=250

--- a/README.md
+++ b/README.md
@@ -1,4 +1,2 @@
 # BigBrother
 World of Warcraft addon; consumable check and raid alerts.  (Not original author, just maintaining.)
-
-Include the Change from rawillkill posted on curse.

--- a/SpellData.lua
+++ b/SpellData.lua
@@ -12,34 +12,34 @@ vars.SpellData.foods = {
 	43722, -- Enlightened
 	43763, -- Food (eating)
 	-- Legion
-	225600, -- Versatility
+	--225600, -- Versatility
 	-- BFA
-	--257410, -- Critical Strike 16
-	--257408, -- Critical Strike 53
+	257410, -- Critical Strike 16
+	257408, -- Critical Strike 53
 	
-	--257422, -- Versatility 12
-	--257424, -- Versatility 16
+	257422, -- Versatility 12
+	257424, -- Versatility 16
 	
-	--259454, -- Agility 22
-	--259448, -- Agility 75
+	259454, -- Agility 22
+	259448, -- Agility 75
 	
-	--259452, -- Strength 12
-	--259456, -- Strength 22
+	259452, -- Strength 12
+	259456, -- Strength 22
 	
-	--259449, -- Intellect 75
-	--259455, -- Intellect 100
+	259449, -- Intellect 75
+	259455, -- Intellect 100
 
 	-- 262571, -- Stamina 11 - 15 min buff (?)
-	--259453, -- Stamina 26
-	--259457, -- Stamina 150
+	259453, -- Stamina 26
+	259457, -- Stamina 150
 	
-	--257418, -- Mastery 12
-	--257420, -- Mastery 70
+	257418, -- Mastery 12
+	257420, -- Mastery 70
 	
-	--257415, -- Haste 16
-	--257413, -- Haste 53
+	257415, -- Haste 16
+	257413, -- Haste 53
 	
-	-- 267948, -- Warfront shit 
+	-- 267948, -- Warfront shit
 	-- 267949, -- Warfront shit
 	-- 267950, -- Warfront shit
 	-- 267951, -- Warfront shit
@@ -90,7 +90,7 @@ vars.SpellData.VantusRunes = {
 	192762, -- Il'gynoth
 	192763, -- Dragons of Nightmare
 	192766, -- Cenarius
-	192764, -- Xavius
+	-192764, -- Xavius
 	-- Trial of Valor
 	229174, -- Odyn
 	229175, -- Guarm
@@ -116,25 +116,13 @@ vars.SpellData.VantusRunes = {
 	237823, -- Fel Titan (Maiden of Vigilance maybe. Fixed id will be asap)
 	237820, -- Fallen Avatar
 	237825, -- Kil'jaeden
-	-- Antorus, the Burning Throne
-	250153, -- Garothi Worldbreaker
-	250156, -- Felhounds of Sargeras
-	250167, -- Antoran High Command
-	250160, -- Portal Keeper Hasabel
-	250150, -- Eonar the Lifebinder
-	250158, -- Imonar the Soulhunter
-	250148, -- Kin'garoth
-	250165, -- Varimathras
-	250163, -- The Coven of Shivarra
-	250144, -- Aggramar
-	250146, -- Argus the Unmaker
 	-- Uldir
 	269276, -- Taloc
 	269405, -- MOTHER
 	269407, -- Zek'vohj
 	269408, -- Fetid Devourer
 	269409, -- Blood of G'huun
-	269411, -- Zul
+    269411, -- Zul
 	269412, -- Mythrax
 	269413, -- G'huun
 }
@@ -204,6 +192,7 @@ vars.SpellData.flasks = {
 	188033,	-- Flask of the Seventh Demon
 	188034,	-- Flask of the Countless Armies
 	188035,	-- Flask of Ten Thousand Scars
+	242551, -- Repurposed Fel Focuser
 	-- Flask BFA
 	251839, -- Flask of the Undertow (Str)
 	251838, -- Flask of the Vast Horizon (Sta)
@@ -305,7 +294,6 @@ vars.SpellData.ccspells = {
 	6358, -- Seduction
 	115268, -- Mesmerize
 	339, -- Entangling Roots
-	2637, -- Hibernate
 	115078, -- Paralysis (Monk)
 	122224, -- Impaling Spear (HoF: Wind Lord Mel'jarak)
 	122220, -- Impaling Spear (HoF: Wind Lord Mel'jarak)

--- a/SpellData.lua
+++ b/SpellData.lua
@@ -90,7 +90,7 @@ vars.SpellData.VantusRunes = {
 	192762, -- Il'gynoth
 	192763, -- Dragons of Nightmare
 	192766, -- Cenarius
-	-192764, -- Xavius
+	192764, -- Xavius
 	-- Trial of Valor
 	229174, -- Odyn
 	229175, -- Guarm

--- a/libs/AceAddon-2.0/AceAddon-2.0.lua
+++ b/libs/AceAddon-2.0/AceAddon-2.0.lua
@@ -1,4 +1,4 @@
---[[
+﻿--[[
 Name: AceAddon-2.0
 Revision: $Rev: 1116 $
 Developed by: The Ace Development Team (http://www.wowace.com/index.php/The_Ace_Development_Team)

--- a/locale.lua
+++ b/locale.lua
@@ -12,7 +12,7 @@ vars.L = setmetatable({},{
 })
 
 Ld["A new version of Big Brother (%s) is available for download at:"] = "A new version of Big Brother (%s) is available for download at:"
-Ld["A quick report that shows who does not have flasks, elixirs or food."] = "A quick report that shows who does not have flasks, elixirs or food."
+Ld["A report that shows who does not have flasks, elixirs or food."] = "A report that shows who does not have flasks, elixirs or food."
 Ld["Armor"] = "Armor"
 Ld["Augment Runes"] = "Augment Runes"
 Ld["Auras"] = "Auras"
@@ -21,6 +21,7 @@ Ld["Battleground"] = "Battleground"
 Ld["BuffCheck"] = "BuffCheck"
 Ld["|cffff8040Left Click|r to toggle the buff window"] = "|cffff8040Left Click|r to toggle the buff window"
 Ld["|cffff8040Right Click|r for menu"] = "|cffff8040Right Click|r for menu"
+Ld["Check"] = "Check"
 Ld["Checks"] = "Checks"
 Ld["Checks for flasks, elixirs and food buffs."] = "Checks for flasks, elixirs and food buffs."
 Ld["Click to add this event to chat"] = "Click to add this event to chat"
@@ -127,7 +128,7 @@ La["Vantus Rune"] = "Vantus Rune"
 
 if locale == "frFR" then do end
 La["A new version of Big Brother (%s) is available for download at:"] = "Une nouvelle version de Big Brother (%s) est disponible au téléchargement à :" -- Needs review
-La["A quick report that shows who does not have flasks, elixirs or food."] = "Un rapport rapide qui indique les personnes sans flacon, élixir ou buff de nourriture."
+La["A report that shows who does not have flasks, elixirs or food."] = "Un rapport rapide qui indique les personnes sans flacon, élixir ou buff de nourriture."
 La["Armor"] = "Armure" -- Needs review
 -- La["Augment Runes"] = ""
 La["Auras"] = "Auras" -- Needs review
@@ -239,7 +240,7 @@ La["Whisper"] = "Chuchoter"
 
 elseif locale == "deDE" then do end
 La["A new version of Big Brother (%s) is available for download at:"] = "Eine neue Version von Big Brother (%s) ist zum Download verfügbar auf:"
-La["A quick report that shows who does not have flasks, elixirs or food."] = "Eine Schnellprüfung, wer keine Fläschchen, Elixiere oder Essen-Buffs hat."
+La["A report that shows who does not have flasks, elixirs or food."] = "Eine Schnellprüfung, wer keine Fläschchen, Elixiere oder Essen-Buffs hat."
 La["Armor"] = "Rüstung"
 La["Augment Runes"] = "Verstärkungsrunen"
 La["Auras"] = "Auren"
@@ -351,7 +352,7 @@ La["Whisper"] = "Flüstern"
 
 elseif locale == "koKR" then do end
 La["A new version of Big Brother (%s) is available for download at:"] = "새로운 버젼(%s)의 Big Brother을 사용할수 있습니다. 아래 페이지에서 내려받으세요." -- Needs review
-La["A quick report that shows who does not have flasks, elixirs or food."] = "영약/비약/음식 버프가 없는 사람을 간단히 확인합니다."
+La["A report that shows who does not have flasks, elixirs or food."] = "영약/비약/음식 버프가 없는 사람을 간단히 확인합니다."
 La["Armor"] = "방어" -- Needs review
 -- La["Augment Runes"] = ""
 La["Auras"] = "오라" -- Needs review
@@ -464,7 +465,7 @@ La["Whisper"] = "귓속말"
 
 elseif locale == "esMX" then do end
 -- La["A new version of Big Brother (%s) is available for download at:"] = ""
--- La["A quick report that shows who does not have flasks, elixirs or food."] = ""
+-- La["A report that shows who does not have flasks, elixirs or food."] = ""
 -- La["Armor"] = ""
 -- La["Augment Runes"] = ""
 -- La["Auras"] = ""
@@ -576,7 +577,7 @@ elseif locale == "esMX" then do end
 
 elseif locale == "ruRU" then do end
 La["A new version of Big Brother (%s) is available for download at:"] = "Доступна для скачивания новая версия Big Brother (%s):" -- Needs review
-La["A quick report that shows who does not have flasks, elixirs or food."] = "Быстрая проверка на наличие баффов от настоев, эликсиров или еды."
+La["A report that shows who does not have flasks, elixirs or food."] = "Быстрая проверка на наличие баффов от настоев, эликсиров или еды."
 La["Armor"] = "Броня" -- Needs review
 -- La["Augment Runes"] = ""
 La["Auras"] = "Ауры" -- Needs review
@@ -688,7 +689,7 @@ La["Whisper"] = "Шепнуть"
 
 elseif locale == "zhCN" then do end
 La["A new version of Big Brother (%s) is available for download at:"] = "新版本的 Big Brother (%s) 已经可以下载：" -- Needs review
-La["A quick report that shows who does not have flasks, elixirs or food."] = "快速报告谁没有合剂，药剂，及食物效果"
+La["A report that shows who does not have flasks, elixirs or food."] = "快速报告谁没有合剂，药剂，及食物效果"
 La["Armor"] = "护甲" -- Needs review
 -- La["Augment Runes"] = ""
 La["Auras"] = "Buff/Debuff" -- Needs review
@@ -800,7 +801,7 @@ La["Whisper"] = "密语"
 
 elseif locale == "esES" then do end
 La["A new version of Big Brother (%s) is available for download at:"] = "Una nueva versión de Big Brother ( %s ) está disponible para su descarga en:"
-La["A quick report that shows who does not have flasks, elixirs or food."] = "Un informe rápido que muestra quién no tiene frasco, elixir o comida."
+La["A report that shows who does not have flasks, elixirs or food."] = "Un informe rápido que muestra quién no tiene frasco, elixir o comida."
 La["Armor"] = "Armadura"
 -- La["Augment Runes"] = ""
 La["Auras"] = "Auras"
@@ -912,7 +913,7 @@ La["Whisper"] = "Susurrar"
 
 elseif locale == "zhTW" then do end
 La["A new version of Big Brother (%s) is available for download at:"] = "新版本的Big Brother(%s)已可於: 下載"
-La["A quick report that shows who does not have flasks, elixirs or food."] = "快速檢查回報誰沒有藥水/藥劑/食物 buffs"
+La["A report that shows who does not have flasks, elixirs or food."] = "快速檢查回報誰沒有藥水/藥劑/食物 buffs"
 La["Armor"] = "護甲"
 -- La["Augment Runes"] = ""
 La["Auras"] = "光環"
@@ -1024,7 +1025,7 @@ La["Whisper"] = "密語"
 
 elseif locale == "ptBR" then do end
 La["A new version of Big Brother (%s) is available for download at:"] = "Uma nova versão do Big Brother (%s) está disponível para download em:"
-La["A quick report that shows who does not have flasks, elixirs or food."] = "Um relatório rápido que mostra quem não tem frasco, elixir ou comida."
+La["A report that shows who does not have flasks, elixirs or food."] = "Um relatório rápido que mostra quem não tem frasco, elixir ou comida."
 La["Armor"] = "Armadura"
 -- La["Augment Runes"] = ""
 -- La["Auras"] = ""


### PR DESCRIPTION
I have created a new update for BigBrother. I've added a check (internal) to confirm that the buffs belong to BFA. Thus old buffs are now correctly grayed out in the window and the check message. I've also added a new method to show the buff tooltip on mouse over.
Fixed the issues with the CC breaking message.

Known Issues:
For pandas the "on mouse over"-tooltip (the "Well Fed"-value) will be wrong. I had to use a new method because the old one was removed in the Blizzard API. It shows the value it should have without panda buff.